### PR TITLE
Add transform runtime plugin as default

### DIFF
--- a/packages/babel-preset-base/README.md
+++ b/packages/babel-preset-base/README.md
@@ -72,6 +72,7 @@ be loaded by default, but you can disable it through options.
 -   `@babel/plugin-syntax-import-meta`
 -   `@babel/plugin-proposal-class-properties` - with option `{ "loose": false }`.
 -   `@babel/plugin-proposal-json-strings`
+-   `@babel/plugin-transform-runtime` - with options `{corejs: false, helpers: true, regenerator: true, useESModules: true }`
 
 `@wpackio/babel-preset-base` can be configured to select which `stage-3` plugins to
 exclude.
@@ -121,6 +122,12 @@ Set to `true` to disable [`@babel/plugin-proposal-class-properties`](https://bab
 `boolean`, defaults to `false`.
 
 Set to `true` to disable [`@babel/plugin-proposal-json-strings`](https://babeljs.io/docs/en/babel-plugin-proposal-json-strings).
+
+#### `noRuntime`
+
+`boolean`, defaults to false.
+
+Set to `true` to disable [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime).
 
 #### `presetEnv` Options for `@babel/preset-env`
 

--- a/packages/babel-preset-base/__tests__/preset.spec.ts
+++ b/packages/babel-preset-base/__tests__/preset.spec.ts
@@ -71,8 +71,9 @@ describe('preset in module', () => {
 			noImportMeta: true,
 			noClassProperties: true,
 			noJsonStrings: true,
+			noRuntime: true,
 		});
-		expect(plugins).toHaveLength(1);
+		expect(plugins).toHaveLength(0);
 	});
 
 	describe('for @babel/preset-env', () => {

--- a/packages/babel-preset-base/__tests__/preset.spec.ts
+++ b/packages/babel-preset-base/__tests__/preset.spec.ts
@@ -51,6 +51,7 @@ describe('preset in module', () => {
 			'@babel/plugin-syntax-import-meta',
 			['@babel/plugin-proposal-class-properties'],
 			'@babel/plugin-proposal-json-strings',
+			['@babel/plugin-transform-runtime'],
 		];
 		activePlugins.forEach(plugin => {
 			if (Array.isArray(plugin)) {
@@ -71,7 +72,7 @@ describe('preset in module', () => {
 			noClassProperties: true,
 			noJsonStrings: true,
 		});
-		expect(plugins).toHaveLength(0);
+		expect(plugins).toHaveLength(1);
 	});
 
 	describe('for @babel/preset-env', () => {

--- a/packages/babel-preset-base/package.json
+++ b/packages/babel-preset-base/package.json
@@ -22,8 +22,10 @@
     "@babel/plugin-proposal-json-strings": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-syntax-import-meta": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
-    "@babel/preset-react": "^7.0.0"
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.4.4"
   },
   "peerDependencies": {
     "@babel/core": ">=7.0.0"

--- a/packages/babel-preset-base/src/preset.ts
+++ b/packages/babel-preset-base/src/preset.ts
@@ -82,6 +82,18 @@ export const preset = (opts: PresetOptions | null = {}) => {
 		}
 	});
 
+	// We include @babel/plugin-transform-runtime by default in order to
+	// properly transform e.g. async/await
+	plugins.push([
+		'@babel/plugin-transform-runtime',
+		{
+			corejs: false,
+			helpers: false,
+			regenerator: true,
+			useESModules: false,
+		},
+	]);
+
 	// Return the preset and some of stage-3 plugins
 	// We will remove them, once it becomes stage-4, i.e included in preset-env
 	return {

--- a/packages/babel-preset-base/src/preset.ts
+++ b/packages/babel-preset-base/src/preset.ts
@@ -5,6 +5,7 @@ export interface PresetOptions {
 	noImportMeta?: boolean;
 	noClassProperties?: boolean;
 	noJsonStrings?: boolean;
+	noRuntime?: boolean;
 	hasReact?: boolean;
 	presetEnv?: {};
 	presetReact?: {};

--- a/packages/babel-preset-base/src/preset.ts
+++ b/packages/babel-preset-base/src/preset.ts
@@ -88,9 +88,9 @@ export const preset = (opts: PresetOptions | null = {}) => {
 		'@babel/plugin-transform-runtime',
 		{
 			corejs: false,
-			helpers: false,
+			helpers: true,
 			regenerator: true,
-			useESModules: false,
+			useESModules: true,
 		},
 	]);
 

--- a/packages/babel-preset-base/src/preset.ts
+++ b/packages/babel-preset-base/src/preset.ts
@@ -74,6 +74,15 @@ export const preset = (opts: PresetOptions | null = {}) => {
 			{ loose: false },
 		],
 		noJsonStrings: '@babel/plugin-proposal-json-strings',
+		noRuntime: [
+			'@babel/plugin-transform-runtime',
+			{
+				corejs: false,
+				helpers: true,
+				regenerator: true,
+				useESModules: true,
+			},
+		],
 	};
 	// Add them, only if user hasn't explicitly disabled it
 	Object.keys(wannabePlugins).forEach((pKey: string) => {
@@ -81,18 +90,6 @@ export const preset = (opts: PresetOptions | null = {}) => {
 			plugins.push(wannabePlugins[pKey]);
 		}
 	});
-
-	// We include @babel/plugin-transform-runtime by default in order to
-	// properly transform e.g. async/await
-	plugins.push([
-		'@babel/plugin-transform-runtime',
-		{
-			corejs: false,
-			helpers: true,
-			regenerator: true,
-			useESModules: true,
-		},
-	]);
 
 	// Return the preset and some of stage-3 plugins
 	// We will remove them, once it becomes stage-4, i.e included in preset-env

--- a/site/docs/apis/node-api.md
+++ b/site/docs/apis/node-api.md
@@ -32,6 +32,7 @@ module.exports = api => {
 		noImportMeta: false,
 		noClassProperties: false,
 		noJsonStrings: false,
+		noTuntime: false,
 		hasReact: true,
 		presetEnv: {
 			// Override Options for @babel/preset-env
@@ -71,6 +72,7 @@ interface PresetOptions {
 	noImportMeta?: boolean;
 	noClassProperties?: boolean;
 	noJsonStrings?: boolean;
+	noRuntime?: boolean;
 	hasReact?: boolean;
 	presetEnv?: {};
 	presetReact?: {};

--- a/site/docs/tutorials/adding-custom-babel-config.md
+++ b/site/docs/tutorials/adding-custom-babel-config.md
@@ -56,6 +56,7 @@ module.exports = api => {
 		noImportMeta: false,
 		noClassProperties: false,
 		noJsonStrings: false,
+		noRuntime: false,
 		hasReact: true,
 		presetEnv: {
 			// Override Options for @babel/preset-env

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,6 +698,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-runtime@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz#a50f5d16e9c3a4ac18a1a9f9803c107c380bce08"
+  integrity sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -832,6 +842,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
+
+"@babel/runtime@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/template@^7.0.0":
   version "7.2.2"
@@ -2031,7 +2048,7 @@
     "@types/connect" "*"
     "@types/webpack" "*"
 
-"@types/webpack@*", "@types/webpack@^4.4.24", "@types/webpack@^4.4.27":
+"@types/webpack@*", "@types/webpack@^4.4.27":
   version "4.4.29"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.29.tgz#d2a1c1d8c071b06521d32cee1c6b33d704b54b2c"
   integrity sha512-8KVp+cNy9OPYsa4jU6vWsBemn5ixJ0Durh95Cw/YpEKm5ks2ODhdXc4FG3Xc46KIbPrJolwY7mSZFNn1aU3hKg==
@@ -10600,6 +10617,11 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
 regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
@@ -10814,6 +10836,13 @@ resolve@^1.10.0, resolve@^1.4.0, resolve@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.8.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Hi,
Here's a PR adding `@babel/plugin-transform-runtime` to the `@wpackio/babel-preset-base` as mentioned in #479.

All tests pass and the build outputs expected code while I was trying it out on a personal WordPress-project.

## Reasoning

As we discussed in #479, the `@babel/plugin-transform-runtime`-plugin is probably a sane default which enables e.g. async/await-code without needing to include `regeneratorRuntime` in the code it self.

I've chosen to add the plugin by default without an option to remove it. I did that because it's not really a syntax or proposal plugin like the other plugins added.

This choice is up for discussion, maybe there is a reason for being able to remove it?

If so I might just change the code like this (inside `packages/babel-preset-base/src/preset.ts`):

```diff
// Create the plugins
const plugins: singleBabelPlugin[] = [];
const wannabePlugins: PossiblePlugins = {
	noDynamicImport: '@babel/plugin-syntax-dynamic-import',
	noImportMeta: '@babel/plugin-syntax-import-meta',
	noClassProperties: [
		'@babel/plugin-proposal-class-properties',
		{ loose: false },
	],
	noJsonStrings: '@babel/plugin-proposal-json-strings',
+	noRuntime: [
+		'@babel/plugin-transform-runtime',
+		{
+			corejs: false,
+			helpers: true,
+	 		regenerator: true,
+			useESModules: true,
+		}
+	]
};
// Add them, only if user hasn't explicitly disabled it
Object.keys(wannabePlugins).forEach((pKey: string) => {
	if (noPlugins[pKey] !== true) {
		plugins.push(wannabePlugins[pKey]);
	}
});

- // We include @babel/plugin-transform-runtime by default in order to
- // properly transform e.g. async/await
- plugins.push([
- 	'@babel/plugin-transform-runtime',
- 	{
- 		corejs: false,
- 		helpers: true,
- 		regenerator: true,
- 		useESModules: true,
- 	},
- ]);
```

(And of course update the tests as well)