### PR TITLE
Add a way to pass custom ENV variables.

### DIFF
--- a/packages/scripts/__tests__/config/WebpackConfigHelper.spec.ts
+++ b/packages/scripts/__tests__/config/WebpackConfigHelper.spec.ts
@@ -630,4 +630,38 @@ describe('WebpackConfigHelper', () => {
 			expect(cwcDev.getCommon()).toMatchSnapshot();
 		});
 	});
+
+	describe('getEnv', () => {
+		test('Can set custom ENV variables', () => {
+			process.env.WPACKIO_ENV = 'test';
+			process.env.SECRET = 'secret';
+			const cwc = new WebpackConfigHelper(
+				projectConfig.files[0],
+				{
+					...getConfigFromProjectAndServer(
+						projectConfig,
+						serverConfig
+					),
+				},
+				'/foo/bar',
+				false
+			);
+
+			// check in class
+			// @ts-ignore (since this is private). Check it's set.
+			expect(JSON.parse(cwc.customEnv.WPACKIO_ENV)).toBe('test');
+			// @ts-ignore (since this is private). Check secrets can't be exposed client-side
+			expect(cwc.customEnv.SECRET).toBeUndefined();
+
+			// check in define plugin
+			expect(
+				// @ts-ignore (since this is private).
+				JSON.parse(cwc.getPlugins()[0].definitions.WPACKIO_ENV)
+			).toBe('test');
+			expect(
+				// @ts-ignore (since this is private).
+				cwc.customEnv.SECRET
+			).toBeUndefined();
+		});
+	});
 });

--- a/packages/scripts/src/config/WebpackConfigHelper.ts
+++ b/packages/scripts/src/config/WebpackConfigHelper.ts
@@ -113,6 +113,14 @@ export class WebpackConfigHelper {
 	private env: 'development' | 'production';
 
 	/**
+	 * User passed WPACKIO_ env variables, which will be defined
+	 * in webpack with webpack.DefinePlugin.
+	 */
+	private customEnv: {
+		[key: string]: string;
+	};
+
+	/**
 	 * Create an instance of GetEntryAndOutput class.
 	 */
 	constructor(
@@ -130,6 +138,14 @@ export class WebpackConfigHelper {
 		} else {
 			this.env = 'production';
 		}
+
+		// add any env variables that start with WPACKIO_
+		this.customEnv = {};
+		Object.keys(process?.env || {}).forEach(key => {
+			if (key.startsWith('WPACKIO_')) {
+				this.customEnv[key] = JSON.stringify(process?.env?.[key]);
+			}
+		});
 
 		// Create the outputPath, because we would be needing that
 		const { outputPath } = this.config;
@@ -279,6 +295,7 @@ export class WebpackConfigHelper {
 		let plugins: webpack.Plugin[] = [
 			// Define env
 			new webpack.DefinePlugin({
+				...this.customEnv,
 				'process.env.NODE_ENV': JSON.stringify(this.env),
 				'process.env.BABEL_ENV': JSON.stringify(this.env),
 				// Our own access to project config from the modules


### PR DESCRIPTION
This lets the user pass custom ENV variables to webpack's Define plugin. The variable must start with `WPACKIO_` to be included to prevent leaking sensitive env variables client-side. 😁