### PR TITLE
execlude @wordpress/react-i18n from external packages

### DIFF
--- a/packages/scripts/src/dev-utils/ops.ts
+++ b/packages/scripts/src/dev-utils/ops.ts
@@ -32,7 +32,7 @@ export function hasTypeScript(cwd: string): [boolean, string] {
 }
 
 export const WORDPRESS_NAMESPACE = '@wordpress/';
-export const BUNDLED_PACKAGES = ['@wordpress/icons', '@wordpress/interface'];
+export const BUNDLED_PACKAGES = ['@wordpress/icons', '@wordpress/interface', '@wordpress/react-i18n'];
 
 /**
  * Given a string, returns a new string with dash separators converted to


### PR DESCRIPTION
Hi

i cannot use @wordpress/react-i18n whene i megrated to @wpackio/scripts

because the script mark it as external package, I added it to execluded packages list